### PR TITLE
Redefining all Jobs with the latest set

### DIFF
--- a/create-db-ddl.sql
+++ b/create-db-ddl.sql
@@ -969,7 +969,7 @@ insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") va
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(2004, 'KINGSTON UPON HULL');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(2114, 'ISLE OF WIGHT');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(2280, 'MEDWAY');
-insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(2335, 'Lancashire');
+insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(2335, 'LANCASHIRE');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(2372, 'BLACKBURN WITH DARWEN');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(2373, 'BLACKPOOL');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(2465, 'LEICESTER');
@@ -987,7 +987,7 @@ insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") va
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(3430, 'SOUTH STAFFORDSHIRE');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(3530, 'SUFFOLK COASTAL');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(3640, 'SURREY HEATH');
-insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(3725, 'WARWICKshire');
+insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(3725, 'WARWICKSHIRE');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(3940, 'WILTSHIRE');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(4205, 'BOLTON');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(4210, 'BURY');

--- a/create-db-ddl.sql
+++ b/create-db-ddl.sql
@@ -833,6 +833,7 @@ ALTER TABLE cqc."Feedback"
 -- PostgreSQL database dump complete
 --
 
+---- Services
 insert into cqc.services (id, name, category, iscqcregistered, ismain) values (1, 'Carers support', 'Adult community care', 'f', 't');
 insert into cqc.services (id, name, category, iscqcregistered, ismain) values (2, 'Community support and outreach', 'Adult community care', 'f', 't');
 insert into cqc.services (id, name, category, iscqcregistered, ismain) values (3, 'Disability adaptations / assistive technology services', 'Adult community care', 'f', 't');
@@ -872,24 +873,7 @@ insert into cqc.services (id, name, category, iscqcregistered, ismain) values (3
 
 
 
-----Insert From Warren
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (1, 7, 1, 'Number of people receiving care on the completion date');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (2, 9, 1, 'How many beds do you currently have?');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (3, 9, 2, 'How many of those beds are currently used?');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (4, 10, 1, 'How many places do you currently have?');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (5, 10, 2, 'Number of people using the service on the completion date');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (6, 11, 1, 'Number of people receiving care on the completion date');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (7, 12, 1, 'Number of people receiving care on the completion date');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (8, 20, 1, 'How many places do you currently have?');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (9, 20, 2, 'Number of people using the service on the completion date');
-
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (10, 21, 1, 'Number of people using the service on the completion date');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (11, 22, 1, 'Number of people receiving care on the completion date');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (12, 24, 1, 'How many beds do you currently have?');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (13, 24, 2, 'How many of those beds are currently used?');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (14, 25, 1, 'How many beds do you currently have?');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (15, 25, 2, 'How many of those beds are currently used?');
--- INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (16, 35, 1, 'Number of people receiving care on the completion date');
+----Service Capacities
 INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (1, 24, 1, 'How many beds do you currently have?');
 INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (2, 24, 2, 'How many of those beds are currently used?');
 INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (3, 25, 1, 'How many beds do you currently have?');
@@ -907,31 +891,40 @@ INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence"
 INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (15, 11, 1, 'Number of people receiving care on the completion date');
 INSERT INTO cqc."ServicesCapacity" ("ServiceCapacityID", "ServiceID", "Sequence", "Question") values (16, 18, 1, 'Number of people receiving care on the completion date');
 
----------------------
+----Jobs
 
-insert into cqc."Job" ("JobID", "JobName") values (1, 'Senior Care Worker');
-insert into cqc."Job" ("JobID", "JobName") values (2, 'Care Worker');
-insert into cqc."Job" ("JobID", "JobName") values (3, 'Community Support and Outreach Work');
-insert into cqc."Job" ("JobID", "JobName") values (4, 'Advice Guidance and Advocacy');
-insert into cqc."Job" ("JobID", "JobName") values (5, 'Other care-providing job role');
-insert into cqc."Job" ("JobID", "JobName") values (6, 'Senior Management');
-insert into cqc."Job" ("JobID", "JobName") values (7, 'Middle Management');
-insert into cqc."Job" ("JobID", "JobName") values (8, 'First Line Manager');
-insert into cqc."Job" ("JobID", "JobName") values (9, 'Registered Manager');
-insert into cqc."Job" ("JobID", "JobName") values (10, 'Supervisor');
-insert into cqc."Job" ("JobID", "JobName") values (11, 'Managers and staff in care-related but not care-providing roles');
-insert into cqc."Job" ("JobID", "JobName") values (12, 'Social Worker');
-insert into cqc."Job" ("JobID", "JobName") values (13, 'Occupational Therapist');
-insert into cqc."Job" ("JobID", "JobName") values (14, 'Registered Nurse');
-insert into cqc."Job" ("JobID", "JobName") values (15, 'Allied Health Professional');
-insert into cqc."Job" ("JobID", "JobName") values (16, 'Safeguarding and reviewing officer');
-insert into cqc."Job" ("JobID", "JobName") values (17, 'Administrative or office staff not care-providing');
-insert into cqc."Job" ("JobID", "JobName") values (18, 'Ancillary staff not care-providing');
-insert into cqc."Job" ("JobID", "JobName") values (19, 'Activities worker or co-ordinator');
-insert into cqc."Job" ("JobID", "JobName") values (20, 'Occupational therapist assistant');
-insert into cqc."Job" ("JobID", "JobName") values (21, 'Other non-care-providing job roles');
+insert into cqc."Job" ("JobID", "JobName") values (1, 'Activities worker or co-ordinator');
+insert into cqc."Job" ("JobID", "JobName") values (2, 'Administrative / office staff not care-providing');
+insert into cqc."Job" ("JobID", "JobName") values (3, 'Advice, Guidance and Advocacy');
+insert into cqc."Job" ("JobID", "JobName") values (4, 'Allied Health Professional (not Occupational Therapist)');
+insert into cqc."Job" ("JobID", "JobName") values (5, 'Ancillary staff not care-providing');
+insert into cqc."Job" ("JobID", "JobName") values (6, 'Any childrens / young people''s job role');
+insert into cqc."Job" ("JobID", "JobName") values (7, 'Assessment Officer');
+insert into cqc."Job" ("JobID", "JobName") values (8, 'Care Coordinator');
+insert into cqc."Job" ("JobID", "JobName") values (9, 'Care Navigator');
+insert into cqc."Job" ("JobID", "JobName") values (10, 'Care Worker');
+insert into cqc."Job" ("JobID", "JobName") values (11, 'Community, Support and Outreach Work');
+insert into cqc."Job" ("JobID", "JobName") values (12, 'Employment Support');
+insert into cqc."Job" ("JobID", "JobName") values (13, 'First Line Manager');
+insert into cqc."Job" ("JobID", "JobName") values (14, 'Managers and staff care-related but not care-providing');
+insert into cqc."Job" ("JobID", "JobName") values (15, 'Middle Management');
+insert into cqc."Job" ("JobID", "JobName") values (16, 'Nursing Assistant');
+insert into cqc."Job" ("JobID", "JobName") values (17, 'Nursing Associate');
+insert into cqc."Job" ("JobID", "JobName") values (18, 'Occupational Therapist');
+insert into cqc."Job" ("JobID", "JobName") values (19, 'Occupational Therapist Assistant');
+insert into cqc."Job" ("JobID", "JobName") values (20, 'Other job roles directly involved in providing care');
+insert into cqc."Job" ("JobID", "JobName") values (21, 'Other job roles not directly involved in providing care');
+insert into cqc."Job" ("JobID", "JobName") values (22, 'Registered Manager');
+insert into cqc."Job" ("JobID", "JobName") values (23, 'Registered Nurse');
+insert into cqc."Job" ("JobID", "JobName") values (24, 'Safeguarding & Reviewing Officer');
+insert into cqc."Job" ("JobID", "JobName") values (25, 'Senior Care Worker');
+insert into cqc."Job" ("JobID", "JobName") values (26, 'Senior Management');
+insert into cqc."Job" ("JobID", "JobName") values (27, 'Social Worker');
+insert into cqc."Job" ("JobID", "JobName") values (28, 'Supervisor');
+insert into cqc."Job" ("JobID", "JobName") values (29, 'Technician');
 
 
+---- Local Authorities
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(119, 'SOUTH GLOUCESTERSHIRE');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(121, 'NORTH SOMERSET');
 insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") values(230, 'LUTON');


### PR DESCRIPTION
I have revised the comments to be consistent across services, jobs, service capacities and local authorities reference data sets.

I have deleted the old 'service capacities' that were commented out. *Note, I have not many any changes to the current set of service capacities!!!*

I have replaced the full set of 'jobs' with those currently in DEVDB.

I have changed two Local Authority entries for consistent use of uppercase.