### PR TITLE
Workers api

### DIFF
--- a/create-db-ddl.sql
+++ b/create-db-ddl.sql
@@ -54,20 +54,6 @@ ALTER TYPE cqc.job_type OWNER TO sfcadmin;
 
 SET default_with_oids = false;
 
---
--- Name: CqcLog; Type: TABLE; Schema: cqc; Owner: postgres; Tablespace: sfcdevtbs_logins
---
-
-CREATE TABLE IF NOT EXISTS cqc."CqcLog" (
-    id integer NOT NULL,
-    success boolean,
-    message character varying(255),
-    createdat timestamp with time zone NOT NULL,
-    "lastUpdatedAt" text
-);
-
-
-ALTER TABLE cqc."CqcLog" OWNER TO sfcadmin;
 
 --
 -- Name: Establishment; Type: TABLE; Schema: cqc; Owner: sfcadmin; Tablespace: sfcdevtbs_logins
@@ -387,27 +373,6 @@ ALTER TABLE cqc."User_RegistrationID_seq" OWNER TO sfcadmin;
 ALTER SEQUENCE IF EXISTS cqc."User_RegistrationID_seq" OWNED BY cqc."User"."RegistrationID";
 
 
---
--- Name: cqclog_id_seq; Type: SEQUENCE; Schema: cqc; Owner: postgres
---
-
-CREATE SEQUENCE cqc.cqclog_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE cqc.cqclog_id_seq OWNER TO sfcadmin;
-
---
--- Name: cqclog_id_seq; Type: SEQUENCE OWNED BY; Schema: cqc; Owner: postgres
---
-
-ALTER SEQUENCE cqc.cqclog_id_seq OWNED BY cqc."CqcLog".id;
-
 
 --
 -- Name: location_cqcid_seq; Type: SEQUENCE; Schema: cqc; Owner: sfcadmin
@@ -503,12 +468,6 @@ ALTER TABLE cqc.services_id_seq OWNER TO sfcadmin;
 ALTER SEQUENCE IF EXISTS cqc.services_id_seq OWNED BY cqc.services.id;
 
 
---
--- Name: CqcLog id; Type: DEFAULT; Schema: cqc; Owner: postgres
---
-
-ALTER TABLE ONLY cqc."CqcLog" ALTER COLUMN id SET DEFAULT nextval('cqc.cqclog_id_seq'::regclass);
-
 
 --
 -- Name: Establishment EstablishmentID; Type: DEFAULT; Schema: cqc; Owner: sfcadmin
@@ -554,13 +513,6 @@ ALTER TABLE ONLY cqc."User" ALTER COLUMN "RegistrationID" SET DEFAULT nextval('c
 
 
 SET default_tablespace = '';
-
---
--- Name: CqcLog CQCLog_pkey; Type: CONSTRAINT; Schema: cqc; Owner: postgres
---
-
-ALTER TABLE ONLY cqc."CqcLog"
-    ADD CONSTRAINT "CQCLog_pkey" PRIMARY KEY (id);
 
 
 --
@@ -784,19 +736,6 @@ ALTER TABLE ONLY cqc."Establishment"
 ALTER TABLE ONLY cqc."User"
     ADD CONSTRAINT user_establishment_fk FOREIGN KEY ("EstablishmentID") REFERENCES cqc."Establishment"("EstablishmentID");
 
-
---
--- Name: TABLE "CqcLog"; Type: ACL; Schema: cqc; Owner: postgres
---
-
-GRANT ALL ON TABLE cqc."CqcLog" TO sfcadmin;
-
-
---
--- Name: SEQUENCE cqclog_id_seq; Type: ACL; Schema: cqc; Owner: postgres
---
-
-GRANT SELECT,USAGE ON SEQUENCE cqc.cqclog_id_seq TO sfcadmin;
 
 
 --

--- a/delete-db-ddl.sql
+++ b/delete-db-ddl.sql
@@ -1,7 +1,8 @@
 -- other
 DROP TABLE IF EXISTS cqc."Feedback";
 
-
+-- workers
+DROP TABLE IF EXISTS cqc."Worker";
 
 -- establishments
 DROP TABLE IF EXISTS cqc."EstablishmentServices";
@@ -28,6 +29,7 @@ DROP TABLE IF EXISTS cqc.services;
 -- types
 DROP TYPE IF EXISTS cqc.est_employertype_enum;
 DROP TYPE IF EXISTS cqc.job_type;
+DROP TYPE IF EXISTS cqc."WorkerContract";
 
 -- sequences
 DROP SEQUENCE IF EXISTS cqc."EstablishmentCapacity_EstablishmentCapacityID_seq";
@@ -39,3 +41,7 @@ DROP SEQUENCE IF EXISTS cqc."Login_ID_seq";
 DROP SEQUENCE IF EXISTS cqc."User_RegistrationID_seq";
 DROP SEQUENCE IF EXISTS cqc.services_id_seq;
 --DROP SEQUENCE IF EXISTS cqc.cqclog_id_seq;
+
+
+
+

--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	"Contract" cqc."WorkerContract" NOT NULL,
 	"MainJobFK" INTEGER NOT NULL,
 	"ApprovedMentalHealthProfessional" cqc."WorkerApprovedMentalHealthWorker" NULL,
+	"MainJobStartDate" DATE NULL,		-- Just date component, no time.
 	created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
 	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
     CONSTRAINT "Worker_Establishment_fk" FOREIGN KEY ("EstablishmentFK") REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,

--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -1,10 +1,8 @@
 -- DDL for Workers
 
 -- DROP/CLEAN SCHEMA
-DROP TYPE IF EXISTS cqc."WorkerContract";
 DROP TABLE IF EXISTS cqc."Worker";
-
-
+DROP TYPE IF EXISTS cqc."WorkerContract";
 
 -- CREATE/RE-CREATE SCHEMA
 CREATE TYPE cqc."WorkerContract" AS ENUM (
@@ -15,21 +13,22 @@ CREATE TYPE cqc."WorkerContract" AS ENUM (
 	'Other'
 );
 
+
 CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	"ID" serial NOT NULL PRIMARY KEY,
-	"WorkerID" uuid NOT NULL,
-	"EstablishmentFk" integer NOT NULL,
+	"WorkerUID" uuid NOT NULL,
+	"EstablishmentFK" integer NOT NULL,
 	"NameOrID" varchar(50),
 	"Contract" cqc."WorkerContract",
 	"MainJobFK" INTEGER,
 	created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
 	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
     CONSTRAINT "Worker_ID_unq" UNIQUE ("ID"),
-    CONSTRAINT "Worker_Establishment_fk" FOREIGN KEY ("EstablishmentFk") REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
+    CONSTRAINT "Worker_Establishment_fk" FOREIGN KEY ("EstablishmentFK") REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
 	CONSTRAINT "Worker_Job_mainjob_fk" FOREIGN KEY ("MainJobFK") REFERENCES cqc."Job" ("JobID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
-	CONSTRAINT "Worker_NameID_unq" UNIQUE ("NameOrID", "EstablishmentFk")
+	CONSTRAINT "Worker_NameID_unq" UNIQUE ("NameOrID", "EstablishmentFK"),
+	CONSTRAINT "Worker_WorkerUID_unq" UNIQUE ("WorkerUID", "EstablishmentFK")
 );
-
 
 -- REFERENCE DATA
 

--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -3,6 +3,7 @@
 -- DROP/CLEAN SCHEMA
 DROP TABLE IF EXISTS cqc."Worker";
 DROP TYPE IF EXISTS cqc."WorkerContract";
+DROP TYPE IF EXISTS cqc."WorkerApprovedMentalHealthWorker";
 
 -- CREATE/RE-CREATE SCHEMA
 CREATE TYPE cqc."WorkerContract" AS ENUM (
@@ -13,6 +14,12 @@ CREATE TYPE cqc."WorkerContract" AS ENUM (
 	'Other'
 );
 
+CREATE TYPE cqc."WorkerApprovedMentalHealthWorker" AS ENUM (
+	'Yes',
+	'No',
+	'Don''t know'
+);
+
 
 CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	"ID" serial NOT NULL PRIMARY KEY,
@@ -21,6 +28,7 @@ CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	"NameOrID" varchar(50) NOT NULL,
 	"Contract" cqc."WorkerContract" NOT NULL,
 	"MainJobFK" INTEGER NOT NULL,
+	"ApprovedMentalHealthProfessional" cqc."WorkerApprovedMentalHealthWorker" NULL,
 	created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
 	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
     CONSTRAINT "Worker_Establishment_fk" FOREIGN KEY ("EstablishmentFK") REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,

--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -18,31 +18,16 @@ CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	"ID" serial NOT NULL PRIMARY KEY,
 	"WorkerUID" uuid NOT NULL,
 	"EstablishmentFK" integer NOT NULL,
-	"NameOrID" varchar(50),
-	"Contract" cqc."WorkerContract",
-	"MainJobFK" INTEGER,
+	"NameOrID" varchar(50) NOT NULL,
+	"Contract" cqc."WorkerContract" NOT NULL,
+	"MainJobFK" INTEGER NOT NULL,
 	created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
 	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
-    CONSTRAINT "Worker_ID_unq" UNIQUE ("ID"),
     CONSTRAINT "Worker_Establishment_fk" FOREIGN KEY ("EstablishmentFK") REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
 	CONSTRAINT "Worker_Job_mainjob_fk" FOREIGN KEY ("MainJobFK") REFERENCES cqc."Job" ("JobID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
 	CONSTRAINT "Worker_NameID_unq" UNIQUE ("NameOrID", "EstablishmentFK"),
 	CONSTRAINT "Worker_WorkerUID_unq" UNIQUE ("WorkerUID", "EstablishmentFK")
 );
 
--- REFERENCE DATA
-
--- new jobs data
-insert into cqc."Job" ("JobID", "JobName") values (22, 'Any childrens / young people''s job role');
-insert into cqc."Job" ("JobID", "JobName") values (23, 'Assessment Officer');
-insert into cqc."Job" ("JobID", "JobName") values (24, 'Care Coordinator');
-insert into cqc."Job" ("JobID", "JobName") values (25, 'Care Navigator');
-insert into cqc."Job" ("JobID", "JobName") values (26, 'Employment Suppor');
-insert into cqc."Job" ("JobID", "JobName") values (27, 'Nursing Assistant');
-insert into cqc."Job" ("JobID", "JobName") values (28, 'Nursing Associate');
-insert into cqc."Job" ("JobID", "JobName") values (29, 'Technician');
-
--- update jobs
-update cqc."Job" set "JobName"='Allied Health Professional (not Occupational Therapist)' where "JobID"=15;
-update cqc."Job" set "JobName"='Other job roles directly involved in providing care' where "JobID"=5;
-update cqc."Job" set "JobName"='Other job roles not directly involved in providing care' where "JobID"=21;
+CREATE UNIQUE INDEX "Worker_WorkerUID" on cqc."Worker" ("WorkerUID");
+CREATE INDEX "Worker_EstablishmentFK" on cqc."Worker" ("EstablishmentFK");

--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -34,9 +34,10 @@ CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
     CONSTRAINT "Worker_Establishment_fk" FOREIGN KEY ("EstablishmentFK") REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
 	CONSTRAINT "Worker_Job_mainjob_fk" FOREIGN KEY ("MainJobFK") REFERENCES cqc."Job" ("JobID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
-	CONSTRAINT "Worker_NameID_unq" UNIQUE ("NameOrID", "EstablishmentFK"),
 	CONSTRAINT "Worker_WorkerUID_unq" UNIQUE ("WorkerUID", "EstablishmentFK")
 );
 
 CREATE UNIQUE INDEX "Worker_WorkerUID" on cqc."Worker" ("WorkerUID");
 CREATE INDEX "Worker_EstablishmentFK" on cqc."Worker" ("EstablishmentFK");
+
+

--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -1,0 +1,49 @@
+-- DDL for Workers
+
+-- DROP/CLEAN SCHEMA
+DROP TYPE IF EXISTS cqc."WorkerContract";
+DROP TABLE IF EXISTS cqc."Worker";
+
+
+
+-- CREATE/RE-CREATE SCHEMA
+CREATE TYPE cqc."WorkerContract" AS ENUM (
+    'Permanent',
+    'Temporary',
+    'Pool/Bank',
+	'Agency',
+	'Other'
+);
+
+CREATE TABLE IF NOT EXISTS cqc."Worker" (
+	"ID" serial NOT NULL PRIMARY KEY,
+	"WorkerID" uuid NOT NULL,
+	"EstablishmentFk" integer NOT NULL,
+	"NameOrID" varchar(50),
+	"Contract" cqc."WorkerContract",
+	"MainJobFK" INTEGER,
+	created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
+    CONSTRAINT "Worker_ID_unq" UNIQUE ("ID"),
+    CONSTRAINT "Worker_Establishment_fk" FOREIGN KEY ("EstablishmentFk") REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
+	CONSTRAINT "Worker_Job_mainjob_fk" FOREIGN KEY ("MainJobFK") REFERENCES cqc."Job" ("JobID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
+	CONSTRAINT "Worker_NameID_unq" UNIQUE ("NameOrID", "EstablishmentFk")
+);
+
+
+-- REFERENCE DATA
+
+-- new jobs data
+insert into cqc."Job" ("JobID", "JobName") values (22, 'Any childrens / young people''s job role');
+insert into cqc."Job" ("JobID", "JobName") values (23, 'Assessment Officer');
+insert into cqc."Job" ("JobID", "JobName") values (24, 'Care Coordinator');
+insert into cqc."Job" ("JobID", "JobName") values (25, 'Care Navigator');
+insert into cqc."Job" ("JobID", "JobName") values (26, 'Employment Suppor');
+insert into cqc."Job" ("JobID", "JobName") values (27, 'Nursing Assistant');
+insert into cqc."Job" ("JobID", "JobName") values (28, 'Nursing Associate');
+insert into cqc."Job" ("JobID", "JobName") values (29, 'Technician');
+
+-- update jobs
+update cqc."Job" set "JobName"='Allied Health Professional (not Occupational Therapist)' where "JobID"=15;
+update cqc."Job" set "JobName"='Other job roles directly involved in providing care' where "JobID"=5;
+update cqc."Job" set "JobName"='Other job roles not directly involved in providing care' where "JobID"=21;

--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	"NameOrID" varchar(50) NOT NULL,
 	"Contract" cqc."WorkerContract" NOT NULL,
 	"MainJobFK" INTEGER NOT NULL,
-	"ApprovedMentalHealthProfessional" cqc."WorkerApprovedMentalHealthWorker" NULL,
+	"ApprovedMentalHealthWorker" cqc."WorkerApprovedMentalHealthWorker" NULL,
 	"MainJobStartDate" DATE NULL,		-- Just date component, no time.
 	created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
 	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
@@ -39,5 +39,3 @@ CREATE TABLE IF NOT EXISTS cqc."Worker" (
 
 CREATE UNIQUE INDEX "Worker_WorkerUID" on cqc."Worker" ("WorkerUID");
 CREATE INDEX "Worker_EstablishmentFK" on cqc."Worker" ("EstablishmentFK");
-
-


### PR DESCRIPTION
Removing any dependencies on `cqclog` from the original create DDL. This is owing to current deployed databases not easily being able to remove the dependency. It's not being "effectively" used and therefore of little relevance here. Doing this though means I can easily rebuild my local database on-demand.

Significantly includes the initial Workers DB schema up to and including the first screen only: nameId, contract and main job.
