### PR TITLE
Adding Worker record level and property level change/saved audit log

### DIFF
--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -1,11 +1,13 @@
 -- DDL for Workers
 
 -- DROP/CLEAN SCHEMA
+DROP TABLE IF EXISTS cqc."WorkerAudit";
 DROP TABLE IF EXISTS cqc."Worker";
 DROP TYPE IF EXISTS cqc."WorkerContract";
 DROP TYPE IF EXISTS cqc."WorkerApprovedMentalHealthWorker";
 DROP TYPE IF EXISTS cqc."WorkerGender";
 DROP TYPE IF EXISTS cqc."WorkerDisability";
+DROP TYPE IF EXISTS cqc."AuditChangeType";
 
 -- CREATE/RE-CREATE SCHEMA
 CREATE TYPE cqc."WorkerContract" AS ENUM (
@@ -38,26 +40,81 @@ CREATE TYPE cqc."WorkerDisability" AS ENUM (
 
 
 CREATE TABLE IF NOT EXISTS cqc."Worker" (
-	"ID" SERIALl NOT NULL PRIMARY KEY,
+	"ID" SERIAL NOT NULL PRIMARY KEY,
 	"WorkerUID" UUID NOT NULL,
 	"EstablishmentFK" INTEGER NOT NULL,
-	"NameOrID" VARCHAR(50) NOT NULL,
-	"Contract" cqc."WorkerContract" NOT NULL,
-	"MainJobFK" INTEGER NOT NULL,
+	"NameOrIdValue" VARCHAR(50) NOT NULL,
+	"NameOrIdSavedAt" TIMESTAMP NULL,
+	"NameOrIdChangedAt" TIMESTAMP NULL,
+	"NameOrIdSavedBy" VARCHAR(120) NULL,
+	"NameOrIdChangedBy" VARCHAR(120) NULL,
+	"ContractValue" cqc."WorkerContract" NOT NULL,
+	"ContractSavedAt" TIMESTAMP NULL,
+	"ContractChangedAt" TIMESTAMP NULL,
+	"ContractSavedBy" VARCHAR(120) NULL,
+	"ContractChangedBy" VARCHAR(120) NULL,
+	"MainJobFKValue" INTEGER NOT NULL,
+	"MainJobFKSavedAt" TIMESTAMP NULL,
+	"MainJobFKChangedAt" TIMESTAMP NULL,
+	"MainJobFKSavedBy" VARCHAR(120) NULL,
+	"MainJobFKChangedBy" VARCHAR(120) NULL,
 	"ApprovedMentalHealthWorker" cqc."WorkerApprovedMentalHealthWorker" NULL,
-	"MainJobStartDate" DATE NULL,		-- Just date component, no time.
-	"NationalInsuranceNumber" VARCHAR(13) NULL,
-	"DateOfBirth" DATE NULL,
-	"Postcode" VARCHAR(8) NULL,
+	"MainJobStartDateValue" DATE NULL,		-- Just date component, no time.
+	"MainJobStartDateSavedAt" TIMESTAMP NULL,
+	"MainJobStartDateChangedAt" TIMESTAMP NULL,
+	"MainJobStartDateSavedBy" VARCHAR(120) NULL,
+	"MainJobStartDateChangedBy" VARCHAR(120) NULL,
+	"NationalInsuranceNumberValue" VARCHAR(13) NULL,
+	"NationalInsuranceNumberSavedAt" TIMESTAMP NULL,
+	"NationalInsuranceNumberChangedAt" TIMESTAMP NULL,
+	"NationalInsuranceNumberSavedBy" VARCHAR(120) NULL,
+	"NationalInsuranceNumberChangedBy" VARCHAR(120) NULL,
+	"DateOfBirthValue" DATE NULL,
+	"DateOfBirthSavedAt" TIMESTAMP NULL,
+	"DateOfBirthChangedAt" TIMESTAMP NULL,
+	"DateOfBirthSavedBy" VARCHAR(120) NULL,
+	"DateOfBirthChangedBy" VARCHAR(120) NULL,
+	"PostcodeValue" VARCHAR(8) NULL,
+	"PostcodeSavedAt" TIMESTAMP NULL,
+	"PostcodeChangedAt" TIMESTAMP NULL,
+	"PostcodeSavedBy" VARCHAR(120) NULL,
+	"PostcodeChangedBy" VARCHAR(120) NULL,
+	"DisabilityValue" cqc."WorkerDisability" NULL,
+	"DisabilitySavedAt" TIMESTAMP NULL,
+	"DisabilityChangedAt" TIMESTAMP NULL,
+	"DisabilitySavedBy" VARCHAR(120) NULL,
+	"DisabilityChangedBy" VARCHAR(120) NULL,
+	"GenderValue" cqc."WorkerGender" NULL,
+	"GenderSavedAt" TIMESTAMP NULL,
+	"GenderChangedAt" TIMESTAMP NULL,
+	"GenderSavedBy" VARCHAR(120) NULL,
+	"GenderChangedBy" VARCHAR(120) NULL,
 	created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
 	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
+	updatedby VARCHAR(120) NOT NULL,
     CONSTRAINT "Worker_Establishment_fk" FOREIGN KEY ("EstablishmentFK") REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
-	CONSTRAINT "Worker_Job_mainjob_fk" FOREIGN KEY ("MainJobFK") REFERENCES cqc."Job" ("JobID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
-	CONSTRAINT "Worker_WorkerUID_unq" UNIQUE ("WorkerUID", "EstablishmentFK")
+	CONSTRAINT "Worker_Job_mainjob_fk" FOREIGN KEY ("MainJobFKValue") REFERENCES cqc."Job" ("JobID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
+	CONSTRAINT "Worker_WorkerUID_unq" UNIQUE ("WorkerUID")
 );
 
-CREATE UNIQUE INDEX "Worker_WorkerUID" on cqc."Worker" ("WorkerUID");
-CREATE INDEX "Worker_EstablishmentFK" on cqc."Worker" ("EstablishmentFK");
+CREATE UNIQUE INDEX "Worker_WorkerUID" on cqc."Worker" ("WorkerUID") USING btree;
+CREATE INDEX "Worker_EstablishmentFK" on cqc."Worker" ("EstablishmentFK") USING btree;
 
-ALTER TABLE cqc."Worker" ADD COLUMN "Gender" cqc."WorkerGender" NULL;
-ALTER TABLE cqc."Worker" ADD COLUMN "Disability" cqc."WorkerDisability" NULL;
+-- change auditting
+CREATE TYPE cqc."AuditChangeType" AS ENUM (
+	'created',
+	'updated',
+	'saved',
+	'changed'
+);
+CREATE TABLE IF NOT EXISTS cqc."WorkerAudit" (
+	"ID" SERIAL NOT NULL PRIMARY KEY,
+	"WorkerFK" INTEGER NOT NULL,
+	"Username" VARCHAR(120) NOT NULL,
+	"When" TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+	"EventType" cqc."AuditChangeType" NOT NULL,
+	"PropertyName" VARCHAR(100) NULL,
+	"ChangeEvents" JSONB NULL,
+	CONSTRAINT "WorkerAudit_Worker_fk" FOREIGN KEY ("WorkerFK") REFERENCES cqc."Worker" ("ID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+CREATE INDEX "WorkerAudit_WorkerFK" on cqc."WorkerAudit" ("WorkerFK") USING btree;

--- a/worker-db-ddl.sql
+++ b/worker-db-ddl.sql
@@ -58,7 +58,11 @@ CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	"MainJobFKChangedAt" TIMESTAMP NULL,
 	"MainJobFKSavedBy" VARCHAR(120) NULL,
 	"MainJobFKChangedBy" VARCHAR(120) NULL,
-	"ApprovedMentalHealthWorker" cqc."WorkerApprovedMentalHealthWorker" NULL,
+	"ApprovedMentalHealthWorkerValue" cqc."WorkerApprovedMentalHealthWorker" NULL,
+	"ApprovedMentalHealthWorkerSavedAt" TIMESTAMP NULL,
+	"ApprovedMentalHealthWorkerChangedAt" TIMESTAMP NULL,
+	"ApprovedMentalHealthWorkerSavedBy" VARCHAR(120) NULL,
+	"ApprovedMentalHealthWorkerChangedBy" VARCHAR(120) NULL,
 	"MainJobStartDateValue" DATE NULL,		-- Just date component, no time.
 	"MainJobStartDateSavedAt" TIMESTAMP NULL,
 	"MainJobStartDateChangedAt" TIMESTAMP NULL,
@@ -97,8 +101,8 @@ CREATE TABLE IF NOT EXISTS cqc."Worker" (
 	CONSTRAINT "Worker_WorkerUID_unq" UNIQUE ("WorkerUID")
 );
 
-CREATE UNIQUE INDEX "Worker_WorkerUID" on cqc."Worker" ("WorkerUID") USING btree;
-CREATE INDEX "Worker_EstablishmentFK" on cqc."Worker" ("EstablishmentFK") USING btree;
+CREATE UNIQUE INDEX "Worker_WorkerUID" on cqc."Worker" ("WorkerUID");
+CREATE INDEX "Worker_EstablishmentFK" on cqc."Worker" ("EstablishmentFK");
 
 -- change auditting
 CREATE TYPE cqc."AuditChangeType" AS ENUM (
@@ -117,4 +121,4 @@ CREATE TABLE IF NOT EXISTS cqc."WorkerAudit" (
 	"ChangeEvents" JSONB NULL,
 	CONSTRAINT "WorkerAudit_Worker_fk" FOREIGN KEY ("WorkerFK") REFERENCES cqc."Worker" ("ID") MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
 );
-CREATE INDEX "WorkerAudit_WorkerFK" on cqc."WorkerAudit" ("WorkerFK") USING btree;
+CREATE INDEX "WorkerAudit_WorkerFK" on cqc."WorkerAudit" ("WorkerFK");


### PR DESCRIPTION
Note - each property now has individual columns to record the facts:
1. Last Saved At (timestamp for when saving without any care for whether the property changed)
2. Last Changed At (timestamp if at the time of saving, the property value changed)
3. Last Saved By (the username who last made saved the property)
4. Last Changed By (the username who last saved but which changed the property value)

At worker level, introducing "updatedBy" to record who last updated the worker regardless of whether they saved and/or changed any property.

Note - even though we currently have one user/one "establishment/worker" relationship, there is work coming to introduce parent & subsidiaries which mean there will ultimately be multiple users able to update, save and change - including admin users (the client's own support team).

Introducing also the `WorkerAudit` log table, which is simply an audit history of all events.