### PR TITLE
Adding Vacancies, Leavers and Starter declarations.

### DIFF
--- a/create-db-ddl.sql
+++ b/create-db-ddl.sql
@@ -1003,3 +1003,13 @@ ALTER TABLE cqc.location DROP COLUMN cqcid ;
 
 ALTER TABLE cqc.location  add constraint locationid_PK PRIMARY KEY (locationid);
 ALTER TABLE cqc.location  add constraint locationid_Unq UNIQUE  (locationid);
+
+CREATE TYPE cqc.job_declaration AS ENUM (
+    'None',
+    'Don''t know',
+	'With Jobs'
+);
+
+ALTER TABLE cqc."Establishment" add column "Vacancies" cqc.job_declaration NULL;
+ALTER TABLE cqc."Establishment" add column "Starters" cqc.job_declaration NULL;
+ALTER TABLE cqc."Establishment" add column "Leavers" cqc.job_declaration NULL;


### PR DESCRIPTION
A requested enhancement to Establishments is that the activity of "No jobs" and "I don't" for each of Vacancies, Starters and Leavers must be declared, such that the activity last taken can be restore in the UI when it comes to editting the Establishment.