### PR TITLE
Duplicate establishment

### DIFF
--- a/create-db-ddl.sql
+++ b/create-db-ddl.sql
@@ -998,11 +998,10 @@ insert into cqc."LocalAuthority" ("LocalCustodianCode", "LocalAuthorityName") va
 
 
 -- removing the unnecessary location.cqcid and promoting location.locationid as primary key
-ALTER TABLE cqc.location DROP CONSTRAINT location_pkey;
-ALTER TABLE cqc.location DROP COLUMN cqcid ;
-
-ALTER TABLE cqc.location  add constraint locationid_PK PRIMARY KEY (locationid);
-ALTER TABLE cqc.location  add constraint locationid_Unq UNIQUE  (locationid);
+--ALTER TABLE cqc.location DROP CONSTRAINT location_pkey;
+--ALTER TABLE cqc.location DROP COLUMN cqcid ;
+--ALTER TABLE cqc.location  add constraint locationid_PK PRIMARY KEY (locationid);
+--ALTER TABLE cqc.location  add constraint locationid_Unq UNIQUE  (locationid);
 
 CREATE TYPE cqc.job_declaration AS ENUM (
     'None',
@@ -1013,3 +1012,9 @@ CREATE TYPE cqc.job_declaration AS ENUM (
 ALTER TABLE cqc."Establishment" add column "Vacancies" cqc.job_declaration NULL;
 ALTER TABLE cqc."Establishment" add column "Starters" cqc.job_declaration NULL;
 ALTER TABLE cqc."Establishment" add column "Leavers" cqc.job_declaration NULL;
+
+-- https://trello.com/c/LgdigwUb - duplicate establishment
+DROP INDEX IF EXISTS cqc."Establishment_unique_registration";
+DROP INDEX IF EXISTS cqc."Establishment_unique_registration_with_locationid";
+CREATE UNIQUE INDEX IF NOT EXISTS "Establishment_unique_registration" ON cqc."Establishment" ("Name", "PostCode");
+CREATE UNIQUE INDEX IF NOT EXISTS "Establishment_unique_registration_with_locationid" ON cqc."Establishment" ("Name", "PostCode", "LocationID") WHERE "LocationID" IS NOT NULL;

--- a/delete-db-ddl.sql
+++ b/delete-db-ddl.sql
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS cqc."Feedback";
 
 -- workers
 DROP TABLE IF EXISTS cqc."WorkerAudit";
+DROP TABLE IF EXISTS cqc."WorkerJobs";
 DROP TABLE IF EXISTS cqc."Worker";
 
 -- establishments
@@ -30,6 +31,7 @@ DROP TABLE IF EXISTS cqc.services;
 -- types
 DROP TYPE IF EXISTS cqc.est_employertype_enum;
 DROP TYPE IF EXISTS cqc.job_type;
+DROP TYPE IF EXISTS cqc.job_declaration;
 DROP TYPE IF EXISTS cqc."WorkerContract";
 
 -- sequences


### PR DESCRIPTION
Hi Shakir

We used to have a unique constraint on establishment name, but it was too course. Have agreed a revised uniqueness which includes the postcode, and if a CQC site, the location id too. Partial Index is required because the location id is null for non-CQC establishments.

Whilst testing this, I took the opportunity to do a full rebuild on my local database (also to delete the non-compliant test data I had created). This highlighted a dependency missing in the delete/drop DDL which I have corrected and included here.

Thanks