### PR TITLE
Migration 3 - tidy up from this morning's migration

### DIFF
--- a/Migration_DB_Scripts/migration_ddl.sql
+++ b/Migration_DB_Scripts/migration_ddl.sql
@@ -5,21 +5,23 @@ CREATE OR REPLACE FUNCTION migration.DeleteAllTransactional()
   RETURNS void AS $$
 DECLARE
 BEGIN
-  delete from cqc."WorkerAudit";
-  delete from cqc."WorkerJobs";
-  delete from cqc."Worker";
-  delete from cqc."EstablishmentCapacity";
-  delete from cqc."EstablishmentJobs";
-  delete from cqc."EstablishmentServices";
-  delete from cqc."EstablishmentLocalAuthority";
-  delete from cqc."EstablishmentServiceUsers";
+  delete from cqc."WorkerQualification";
+  delete from cqc."WorkerTraining" where "TribalID" IS NOT NULL;
+  delete from cqc."WorkerAudit" where "WorkerFK" in (select distinct "ID" from cqc."Worker" where "TribalID" IS NOT NULL);
+  delete from cqc."WorkerJobs" where "WorkerFK" in (select distinct "ID" from cqc."Worker" where "TribalID" IS NOT NULL);
+  delete from cqc."Worker" where "TribalID" IS NOT NULL;
+  delete from cqc."EstablishmentCapacity" where "EstablishmentID" in (select distinct "EstablishmentID" from cqc."Establishment" where "TribalID" IS NOT NULL);
+  delete from cqc."EstablishmentJobs" where "EstablishmentID" in (select distinct "EstablishmentID" from cqc."Establishment" where "TribalID" IS NOT NULL);
+  delete from cqc."EstablishmentServices" where "EstablishmentID" in (select distinct "EstablishmentID" from cqc."Establishment" where "TribalID" IS NOT NULL);
+  delete from cqc."EstablishmentLocalAuthority" where "EstablishmentID" in (select distinct "EstablishmentID" from cqc."Establishment" where "TribalID" IS NOT NULL);
+  delete from cqc."EstablishmentServiceUsers" where "EstablishmentID" in (select distinct "EstablishmentID" from cqc."Establishment" where "TribalID" IS NOT NULL);
 
-  delete from cqc."Login";
-  delete from cqc."UserAudit";
-  delete from cqc."PasswdResetTracking";
-  delete from cqc."User";
-  delete from cqc."EstablishmentAudit";
-  delete from cqc."Establishment";
+  delete from cqc."Login" where "RegistrationID" in (select distinct "RegistrationID" from cqc."User" where "TribalID" IS NOT NULL);
+  delete from cqc."UserAudit" where "UserFK" in (select distinct "RegistrationID" from cqc."User" where "TribalID" IS NOT NULL);
+  delete from cqc."PasswdResetTracking" where "UserFK" in (select distinct "RegistrationID" from cqc."User" where "TribalID" IS NOT NULL);
+  delete from cqc."User" where "TribalID" IS NOT NULL;
+  delete from cqc."EstablishmentAudit" where "EstablishmentFK" in (select distinct "EstablishmentID" from cqc."Establishment" where "TribalID" IS NOT NULL);
+  delete from cqc."Establishment" where "TribalID" IS NOT NULL;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -380,7 +382,6 @@ BEGIN
     RAISE NOTICE 'Processing tribal worker: % (%)', CurrentWorker.id, CurrentWorker.newworkerid;
     IF CurrentWorker.newworkerid IS NOT NULL THEN
       -- we have already migrated this record - prepare to enrich/embellish the Worker
-      --PERFORM migration.worker_training(CurrentWorker.id, CurrentWorker.newworkerid);
       --PERFORM migration.worker_qualifications(CurrentWorker.id, CurrentWorker.newworkerid);
       PERFORM migration.worker_easy_properties(CurrentWorker.id, CurrentWorker.newworkerid, CurrentWorker);
       PERFORM migration.worker_other_jobs(CurrentWorker.id, CurrentWorker.newworkerid);
@@ -577,10 +578,10 @@ insert into migration.serviceusers (tribalid, sfcid) values
   (1, 1),
   (2, 2),
   (3, 9),
-  (4, 5),
+  (4, 14),
   (5, 4),
   (6, 2),
-  (7, 6),
+  (7, 15),
   (8, 16),
   (9, 18),
   (10, 19),

--- a/Migration_DB_Scripts/migration_patch.sql
+++ b/Migration_DB_Scripts/migration_patch.sql
@@ -58,7 +58,7 @@ alter table cqc."EstablishmentServices" add CONSTRAINT estsrvc_estb_fk FOREIGN K
 
 -- temporarily suspend establishment location foreign key
 ALTER TABLE cqc."Establishment" DROP CONSTRAINT estloc_fk_two;
-ALTER TABLE cqc."Establishment" ADD CONSTRAINT estloc_fk_two FOREIGN KEY ("LocationID")
+ALTER TABLE cqc."Establishment" ADD CONSTRAINT estloc_fk FOREIGN KEY ("LocationID")
         REFERENCES cqcref.location (locationid) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION;

--- a/Migration_DB_Scripts/migration_patch.sql
+++ b/Migration_DB_Scripts/migration_patch.sql
@@ -3,6 +3,8 @@ ALTER TABLE cqc."User" ADD COLUMN "TribalID" INTEGER NULL;
 ALTER TABLE cqc."Establishment" ADD COLUMN "TribalID" INTEGER NULL;
 ALTER TABLE cqc."Worker" ADD COLUMN "TribalID" INTEGER NULL;
 
+ALTER TABLE cqc."WorkerTraining" ADD COLUMN "TribalID" INTEGER NULL;
+
 
 ALTER TABLE cqc."EstablishmentServiceUsers" ADD CONSTRAINT establishment_establishmentserviceusers_fk FOREIGN KEY ("EstablishmentID")
         REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE

--- a/Migration_DB_Scripts/update_establishment.sql
+++ b/Migration_DB_Scripts/update_establishment.sql
@@ -26,9 +26,11 @@ BEGIN
       FETCH MyOtherServices INTO CurrrentOtherService;
       EXIT WHEN NOT FOUND;
 
-      INSERT INTO cqc."EstablishmentServices" ("EstablishmentID", "ServiceID") VALUES (_sfcid, CurrrentOtherService.sfcid);
+      INSERT INTO cqc."EstablishmentServices" ("EstablishmentID", "ServiceID")
+        VALUES (_sfcid, CurrrentOtherService.sfcid)
+        ON CONFLICT DO NOTHING;
 
-      EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process other services: % (%)', _tribalId, _sfcid;
+      --EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process other services: % (%)', _tribalId, _sfcid;
     END;
   END LOOP;
 
@@ -98,18 +100,21 @@ BEGIN
         -- expecting two capacities
 		    IF (CurrrentCapacityService.totalcapacity IS NOT NULL) THEN
         	INSERT INTO cqc."EstablishmentCapacity" ("EstablishmentID", "ServiceCapacityID","Answer")
-          		VALUES (_sfcid, TargetTotalCapacityRecord.servicecapacityid, CurrrentCapacityService.totalcapacity);
+          		VALUES (_sfcid, TargetTotalCapacityRecord.servicecapacityid, CurrrentCapacityService.totalcapacity)
+              ON CONFLICT DO NOTHING;
 		    END IF;
 		
 		    IF (CurrrentCapacityService.currentutilisation IS NOT NULL) THEN
 	        INSERT INTO cqc."EstablishmentCapacity" ("EstablishmentID", "ServiceCapacityID","Answer")
-    	      VALUES (_sfcid, TargetUtilisationRecord.servicecapacityid, CurrrentCapacityService.currentutilisation);
+    	      VALUES (_sfcid, TargetUtilisationRecord.servicecapacityid, CurrrentCapacityService.currentutilisation)
+            ON CONFLICT DO NOTHING;
 		    END IF;
       ELSIF (TargetTotalCapacityRecord.servicecapacityid IS NOT NULL AND TargetUtilisationRecord.servicecapacityid IS NULL) THEN
         -- expecting just one capacity
 		    IF (CurrrentCapacityService.totalcapacity IS NOT NULL) THEN
 	        INSERT INTO cqc."EstablishmentCapacity" ("EstablishmentID", "ServiceCapacityID","Answer")
-    	      VALUES (_sfcid, TargetTotalCapacityRecord.servicecapacityid, CurrrentCapacityService.totalcapacity);
+    	      VALUES (_sfcid, TargetTotalCapacityRecord.servicecapacityid, CurrrentCapacityService.totalcapacity)
+            ON CONFLICT DO NOTHING;
 		    END IF;
       ELSE
         -- do nothing - skip over this source service as target has no capacities
@@ -165,9 +170,11 @@ BEGIN
       FETCH MyServiceUsers INTO CurrrentServiceUser;
       EXIT WHEN NOT FOUND;
 
-      INSERT INTO cqc."EstablishmentServiceUsers" ("EstablishmentID", "ServiceUserID") VALUES (_sfcid, CurrrentServiceUser.sfcid);
+      INSERT INTO cqc."EstablishmentServiceUsers" ("EstablishmentID", "ServiceUserID")
+        VALUES (_sfcid, CurrrentServiceUser.sfcid)
+        ON CONFLICT DO NOTHING;
 
-      EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process service users: % (%)', _tribalId, _sfcid;
+      --EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process service users: % (%)', _tribalId, _sfcid;
     END;
   END LOOP;
 
@@ -240,9 +247,10 @@ BEGIN
       END CASE;
 
       INSERT INTO cqc."EstablishmentLocalAuthority" ("EstablishmentID", "CssrID", "CssR")
-        VALUES (_sfcid, TargetCssrID, TargetCssrName);
+        VALUES (_sfcid, TargetCssrID, TargetCssrName)
+        ON CONFLICT DO NOTHING;
 
-      EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process Local Authority: % (%) - %', _tribalId, _sfcid, CurrrentLocalAuthority.sourcecssr;
+      --EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process Local Authority: % (%) - %', _tribalId, _sfcid, CurrrentLocalAuthority.sourcecssr;
     END;
   END LOOP;
 
@@ -346,24 +354,27 @@ BEGIN
           CurrrentJob.totalvacancies > 0 AND
           CurrrentJob.vacancies > 0) THEN
         INSERT INTO cqc."EstablishmentJobs" ("EstablishmentID", "JobID", "JobType", "Total")
-          VALUES (_sfcid, CurrrentJob.jobid, 'Vacancies', CurrrentJob.vacancies);
+          VALUES (_sfcid, CurrrentJob.jobid, 'Vacancies', CurrrentJob.vacancies)
+          ON CONFLICT DO NOTHING;
       END IF;
 
       IF (CurrrentJob.totalstarters IS NOT NULL AND
           CurrrentJob.totalstarters > 0 AND
           CurrrentJob.starters > 0) THEN
         INSERT INTO cqc."EstablishmentJobs" ("EstablishmentID", "JobID", "JobType", "Total")
-          VALUES (_sfcid, CurrrentJob.jobid, 'Starters', CurrrentJob.starters);
+          VALUES (_sfcid, CurrrentJob.jobid, 'Starters', CurrrentJob.starters)
+          ON CONFLICT DO NOTHING;
       END IF;
          
       IF (CurrrentJob.totalleavers IS NOT NULL AND
           CurrrentJob.totalleavers > 0 AND
           CurrrentJob.leavers > 0) THEN
         INSERT INTO cqc."EstablishmentJobs" ("EstablishmentID", "JobID", "JobType", "Total")
-          VALUES (_sfcid, CurrrentJob.jobid, 'Leavers', CurrrentJob.leavers);
+          VALUES (_sfcid, CurrrentJob.jobid, 'Leavers', CurrrentJob.leavers)
+          ON CONFLICT DO NOTHING;
       END IF;
 
-      EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process Job with target role: % (%) - %', _tribalId, _sfcid, CurrrentJob.jobid;
+      --EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process Job with target role: % (%) - %', _tribalId, _sfcid, CurrrentJob.jobid;
     END;
   END LOOP;
 

--- a/Migration_DB_Scripts/update_worker.sql
+++ b/Migration_DB_Scripts/update_worker.sql
@@ -480,7 +480,9 @@ BEGIN
       FETCH MyOtherJobs INTO CurrrentOtherJob;
       EXIT WHEN NOT FOUND;
 
-      INSERT INTO cqc."WorkerJobs" ("WorkerFK", "JobFK") VALUES (_sfcid, CurrrentOtherJob.sfcid);
+      INSERT INTO cqc."WorkerJobs" ("WorkerFK", "JobFK")
+        VALUES (_sfcid, CurrrentOtherJob.sfcid)
+        ON CONFLICT DO NOTHING;
 
       EXCEPTION WHEN OTHERS THEN RAISE WARNING 'Failed to process other jobs: % (%)', _tribalId, _sfcid;
     END;

--- a/Migration_DB_Scripts/update_worker_training_and_qualifications.sql
+++ b/Migration_DB_Scripts/update_worker_training_and_qualifications.sql
@@ -16,3 +16,78 @@ BEGIN
   RAISE NOTICE '... mapping qualifications';
 END;
 $$ LANGUAGE plpgsql;
+
+DROP FUNCTION IF EXISTS migration.generate_uuid;
+CREATE OR REPLACE FUNCTION migration.generate_uuid()
+  RETURNS UUID AS $$
+DECLARE
+  new_uid UUID;
+BEGIN
+  new_uid := (SELECT CAST(substr(CAST(MyUUID."UID" AS TEXT), 0, 15) || '4' || substr(CAST(MyUUID."UID" AS TEXT), 16, 3) || '-89' || substr(CAST(MyUUID."UID" AS TEXT), 22, 36) AS UUID) "UIDv4"
+    FROM (SELECT uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) AS "UID"));
+
+  return new_uid;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- this more efficient method of worker training record using bulk inserts and updates
+DROP FUNCTION IF EXISTS migration.worker_bulk_training;
+CREATE OR REPLACE FUNCTION migration.worker_bulk_training()
+  RETURNS void AS $$
+DECLARE
+BEGIN
+  RAISE NOTICE '... migrating Worker training records (in bulk)';
+
+  INSERT INTO cqc."WorkerTraining" (
+	"TribalID",
+	"UID",
+	"WorkerFK",
+	"CategoryFK",
+	"Title",
+	"Accredited",
+	"Completed",
+	"Expires",
+	"Notes",
+	created,
+	updated,
+	updatedby)
+	SELECT
+		training_tribalid,
+		target_uid,
+		target_workerfk,
+		target_training_id,
+		target_title,
+		target_accredited::cqc."WorkerTrainingAccreditation",
+		target_completed,
+		target_expires,
+		target_notes,
+		target_created,
+		target_updated,
+		target_updatedby
+	FROM (SELECT
+			worker_training.id AS training_tribalid,
+			"Worker"."ID" AS target_workerfk,
+			worker_training.training_category_id AS tribal_training_id,
+			trainingcategories.sfcid AS target_training_id,
+			CASE WHEN length(worker_training.training_name) > 120 THEN LEFT(worker_training.training_name, 120) ELSE worker_training.training_name END AS target_title,
+			CASE WHEN length(worker_training.training_name) > 120 THEN worker_training.training_name ELSE NULL END AS target_notes,
+			worker_training.achievedate as target_completed,
+			worker_training.expirydate as target_expires,
+			CASE WHEN worker_training.isaccredited = 0 THEN 'No' WHEN worker_training.isaccredited = 1 THEN 'Yes' ELSE NULL END AS target_accredited,
+			worker_training.createddate AS target_created,
+			COALESCE(worker_training.updateddate, worker_training.createddate) AS target_updated,
+			'migration' AS target_updatedby,
+			migration.generate_uuid() AS target_uid
+		FROM worker_training
+			INNER JOIN worker
+				INNER JOIN establishment ON establishment.id = worker.establishment_id
+				INNER JOIN cqc."Worker" ON "Worker"."TribalID" = worker.id
+				ON worker.id = worker_training.worker_id
+			LEFT JOIN migration.trainingcategories ON trainingcategories.tribalid = worker_training.training_category_id
+			LEFT JOIN cqc."WorkerTraining" ON "WorkerTraining"."TribalID" = worker_training.id
+		WHERE establishment.id IN (248,189859,225383,59, 248, 669, 187078, 215842, 162286, 2533, 2952, 200560, 225586, 3278, 60682, 5228, 12937, 232842, 10121, 10757, 216264, 12041, 17047, 177958, 136485, 15000, 20876, 233642, 17661, 168369, 40762, 205162, 154806, 42683, 45882, 196119, 85603, 181062, 218926, 196840, 144133, 215263, 170258, 217893, 231842)
+		  AND "WorkerTraining"."TribalID" IS NULL
+		ORDER BY target_created) AllTrainingRecords;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Hi Shakir

A quick PR for you which covers off the changes I had to make this morning to get the latest migration working.

A softening on inserts to handle duplicates - note, I had already raised duplicates in the migration report; impacts establishments and workers.

Plus a correction to the patch schema for removing the establishment/location constraint.