### PR TITLE
Parents and subs

### DIFF
--- a/UAT/V1.9-patch.sql
+++ b/UAT/V1.9-patch.sql
@@ -24,7 +24,7 @@ CREATE OR REPLACE VIEW "cqc"."AllEstablishmentAndWorkersVW" AS
     "Establishment"."OverallWdfEligibility",
     "Establishment"."LastWdfEligibility" AS "EstablishmentLastWdfEligibility",
     "Establishment"."IsParent",
-    "Establishment"."ParentID",
+    "Establishment"."ParentUID",
     "Establishment"."NameValue",
     "Establishment"."NameSavedAt",
     "Establishment"."NameChangedAt",

--- a/UAT/V1.9-patch.sql
+++ b/UAT/V1.9-patch.sql
@@ -1,3 +1,16 @@
+-- V1.9 patch - parents and subs
+
+-- establishment facts
+ALTER TABLE cqc."Establishment" ADD COLUMN "IsParent" BOOLEAN DEFAULT FALSE;
+ALTER TABLE cqc."Establishment" ADD COLUMN "ParentID" INTEGER NULL;
+ALTER TABLE cqc."Establishment" ADD COLUMN "ParentUID" UUID NULL;
+ALTER TABLE cqc."Establishment" ADD CONSTRAINT establishment_establishment_parent_fk FOREIGN KEY ("ParentID")
+        REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION;
+
+
+-- analysis view
 DROP VIEW IF EXISTS "cqc"."AllEstablishmentAndWorkersVW";
 CREATE OR REPLACE VIEW "cqc"."AllEstablishmentAndWorkersVW" AS
   SELECT

--- a/create-db-ddl.sql
+++ b/create-db-ddl.sql
@@ -118,6 +118,9 @@ CREATE TABLE IF NOT EXISTS cqc."Establishment" (
     "IsRegulated" boolean NOT NULL,
     "OverallWdfEligibility" timestamp without time zone NULL,
     "LastWdfEligibility" timestamp without time zone NULL,
+    "IsParent" BOOLEAN DEFAULT FALSE,
+    "ParentID" INTEGER NULL,
+    "ParentUID" UUID NULL,
     "NameValue" text NOT NULL,
     "NameSavedAt" TIMESTAMP NULL,
     "NameChangedAt" TIMESTAMP NULL,
@@ -185,7 +188,10 @@ CREATE TABLE IF NOT EXISTS cqc."Establishment" (
 ALTER TABLE cqc."Establishment" OWNER TO sfcadmin;
 ALTER TABLE ONLY cqc."Establishment"
     ADD CONSTRAINT unqestbid UNIQUE ("EstablishmentID");
-
+ALTER TABLE cqc."Establishment" ADD CONSTRAINT establishment_establishment_parent_fk FOREIGN KEY ("ParentID")
+        REFERENCES cqc."Establishment" ("EstablishmentID") MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION;
 
 --SET default_tablespace = '';
 


### PR DESCRIPTION
Introducing parents & subs; just two additional fields to the Establishment table. Note, these are not managed properties, so they are simple database columns.

I've also updated the analysis view, so the parent/sub relationships can be exported for the analytics team.

The original create DDL has been updated - ready to build a cqc schema from scratch, but I've also included patch SQL too (we're not update V1.9); note, a view cannot be altered, it must be replaced in it's entirely.