### PR TITLE
Changes captured during the cohort 2 cutover. Both of these would hav…

### DIFF
--- a/Migration_DB_Scripts/migration_ddl.sql
+++ b/Migration_DB_Scripts/migration_ddl.sql
@@ -560,7 +560,7 @@ BEGIN
       PERFORM migration.establishment_capacities(CurrentEstablishment.id, ThisEstablishmentID);
       PERFORM migration.establishment_service_users(CurrentEstablishment.id, ThisEstablishmentID);
       PERFORM migration.establishment_local_authorities(CurrentEstablishment.id, ThisEstablishmentID, CurrentEstablishment.visiblecsci);
-      PERFORM migration.establishment_jobs(CurrentEstablishment.id, CurrentEstablishment.newestablishmentid);
+      PERFORM migration.establishment_jobs(CurrentEstablishment.id, ThisEstablishmentID);
 
     END IF;
 

--- a/Migration_DB_Scripts/migration_password_patch.sql
+++ b/Migration_DB_Scripts/migration_password_patch.sql
@@ -1,3 +1,5 @@
 ALTER TABLE cqc."Login" ADD COLUMN "TribalHash" VARCHAR(128) NULL;
 ALTER TABLE cqc."Login" ADD COLUMN "TribalSalt" VARCHAR(50) NULL;
 ALTER TABLE cqc."User" ADD COLUMN "TribalPasswordAnswer" VARCHAR(255) NULL;
+
+ALTER TABLE cqc."Establishment" DROP CONSTRAINT estloc_fk;


### PR DESCRIPTION
…e been caught in the pre-cutover tasks.