### PR TITLE
Backend api admin role

### DIFF
--- a/UAT/V1.10.10_patch.sql
+++ b/UAT/V1.10.10_patch.sql
@@ -1,11 +1,8 @@
-
 ALTER TABLE cqc."Worker" ADD COLUMN "LocalIdentifierValue" TEXT NULL;
-ALTER TABLE cqc."Worker" ADD COLUMN "LocalIdentifierSavedAt" TEXT NULL;
+ALTER TABLE cqc."Worker" ADD COLUMN "LocalIdentifierSavedAt" TIMESTAMP NULL;
 ALTER TABLE cqc."Worker" ADD COLUMN "LocalIdentifierSavedBy" TEXT NULL;
-ALTER TABLE cqc."Worker" ADD COLUMN "LocalIdentifierChangedAt" TEXT NULL;
+ALTER TABLE cqc."Worker" ADD COLUMN "LocalIdentifierChangedAt" TIMESTAMP NULL;
 ALTER TABLE cqc."Worker" ADD COLUMN "LocalIdentifierChangedBy" TEXT NULL;
 
 ALTER TABLE ONLY cqc."Worker"
     ADD CONSTRAINT "worker_LocalIdentifier_unq" UNIQUE ("LocalIdentifierValue", "EstablishmentFK");
-
-

--- a/UAT/V1.10.11_patch.sql
+++ b/UAT/V1.10.11_patch.sql
@@ -4,3 +4,4 @@
 -- ALTER TYPE cqc.user_role ADD VALUE 'Admin';
 
 ALTER TABLE cqc."User" ALTER COLUMN "EstablishmentID" DROP NOT NULL;
+ALTER TABLE cqc."User" DROP COLUMN "IsAdmin";

--- a/UAT/V1.10.11_patch.sql
+++ b/UAT/V1.10.11_patch.sql
@@ -1,0 +1,6 @@
+--https://trello.com/c/74VGreZm - admin user role
+
+-- run the following command manually!!!
+-- ALTER TYPE cqc.user_role ADD VALUE 'Admin';
+
+ALTER TABLE cqc."User" ALTER COLUMN "EstablishmentID" DROP NOT NULL;

--- a/UAT/V1.10.9_patch.sql
+++ b/UAT/V1.10.9_patch.sql
@@ -4,13 +4,11 @@
 --ALTER TABLE cqc."Establishment" DROP COLUMN "LocalIdentifier";
 --ALTER TABLE ONLY cqc."Establishment" DROP CONSTRAINT "establishment_LocalIdentifier_unq";
 
-
 -- new patch
 ALTER TABLE cqc."Establishment" ADD COLUMN "LocalIdentifierValue" TEXT NULL;
-ALTER TABLE cqc."Establishment" ADD COLUMN "LocalIdentifierSavedAt" TEXT NULL;
+ALTER TABLE cqc."Establishment" ADD COLUMN "LocalIdentifierSavedAt" TIMESTAMP NULL;
 ALTER TABLE cqc."Establishment" ADD COLUMN "LocalIdentifierSavedBy" TEXT NULL;
-ALTER TABLE cqc."Establishment" ADD COLUMN "LocalIdentifierChangedAt" TEXT NULL;
+ALTER TABLE cqc."Establishment" ADD COLUMN "LocalIdentifierChangedAt" TIMESTAMP NULL;
 ALTER TABLE cqc."Establishment" ADD COLUMN "LocalIdentifierChangedBy" TEXT NULL;
-
 
 ALTER TABLE ONLY cqc."Establishment" ADD CONSTRAINT "establishment_LocalIdentifier_unq" UNIQUE ("LocalIdentifierValue");

--- a/create-db-ddl.sql
+++ b/create-db-ddl.sql
@@ -566,7 +566,6 @@ CREATE TABLE IF NOT EXISTS cqc."User" (
     "SecurityQuestionAnswerChangedAt" TIMESTAMP NULL,
     "SecurityQuestionAnswerSavedBy" VARCHAR(120) NULL,
     "SecurityQuestionAnswerChangedBy" VARCHAR(120) NULL,
-    "AdminUser" boolean NOT NULL,
     created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
 	updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),	-- note, on creation of record, updated and created are equal
 	updatedby VARCHAR(120) NOT NULL

--- a/create-db-ddl.sql
+++ b/create-db-ddl.sql
@@ -514,7 +514,8 @@ ALTER TABLE cqc."ServicesCapacity" OWNER TO sfcadmin;
 -- An Establishment's User can take one of two roles: Edit or Read Only
 CREATE TYPE cqc.user_role AS ENUM (
     'Read',
-    'Edit'
+    'Edit',
+    'Admin'
 );
 
 --SET default_tablespace = sfcdevtbs_logins;
@@ -533,7 +534,7 @@ CREATE TABLE IF NOT EXISTS cqc."User" (
     "UserRoleChangedAt" TIMESTAMP NULL,
     "UserRoleSavedBy" VARCHAR(120) NULL,
     "UserRoleChangedBy" VARCHAR(120) NULL,
-    "EstablishmentID" integer NOT NULL,
+    "EstablishmentID" integer NULL,
     "Archived" BOOLEAN DEFAULT false,
     "FullNameValue" character varying(120) NOT NULL,
     "FullNameSavedAt" TIMESTAMP NULL,


### PR DESCRIPTION
Includes softening the NOT NULL constraint of User.EstablishmentID.

Identified during testing the admin user's change audit history, fixing the type fo Local Identifier SavedAt and ChangedAt columns on Establishment and Worker.